### PR TITLE
#35829 Update/Fix Font Awesome icons

### DIFF
--- a/django/forms/forms.py
+++ b/django/forms/forms.py
@@ -316,7 +316,7 @@ class BaseForm(RenderableFormMixin):
         """
         Clean all of self.data and populate self._errors and self.cleaned_data.
         """
-        self._errors = ErrorDict()
+        self._errors = ErrorDict(renderer=self.renderer)
         if not self.is_bound:  # Stop further processing.
             return
         self.cleaned_data = {}

--- a/django/forms/utils.py
+++ b/django/forms/utils.py
@@ -163,6 +163,7 @@ class ErrorList(UserList, list, RenderableErrorMixin):
     def copy(self):
         copy = super().copy()
         copy.error_class = self.error_class
+        copy.renderer = self.renderer
         return copy
 
     def get_json_data(self, escape_html=False):

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -4849,6 +4849,12 @@ class RendererTests(SimpleTestCase):
         form = CustomForm(renderer=custom)
         self.assertEqual(form.renderer, custom)
 
+    def test_get_context_errors(self):
+        custom = CustomRenderer()
+        form = Form(renderer=custom)
+        context = form.get_context()
+        self.assertEqual(context["errors"].renderer, custom)
+
 
 class TemplateTests(SimpleTestCase):
     def test_iterate_radios(self):

--- a/tests/forms_tests/tests/test_forms.py
+++ b/tests/forms_tests/tests/test_forms.py
@@ -5313,6 +5313,22 @@ class OverrideTests(SimpleTestCase):
             "required></p>",
         )
 
+    def test_custom_renderer_error_dict(self):
+        class CustomRenderer(DjangoTemplates):
+            def render(self, template_name, context, request=None):
+                if template_name == "django/forms/errors/dict/default.html":
+                    return "<strong>So many errors!</strong>"
+                return super().render(template_name, context, request)
+
+        form = Form({}, renderer=CustomRenderer())
+        form.full_clean()
+        form.add_error(None, "Test error")
+
+        self.assertHTMLEqual(
+            form.errors.render(),
+            "<strong>So many errors!</strong>",
+        )
+
     def test_cyclic_context_boundfield_render(self):
         class FirstNameForm(Form):
             first_name = CharField()

--- a/tests/forms_tests/tests/test_utils.py
+++ b/tests/forms_tests/tests/test_utils.py
@@ -162,6 +162,24 @@ class FormsUtilsTestCase(SimpleTestCase):
             '<a href="http://www.example.com/">example</a></li></ul>',
         )
 
+    def test_error_list_copy(self):
+        e = ErrorList(
+            [
+                ValidationError(
+                    message="message %(i)s",
+                    params={"i": 1},
+                ),
+                ValidationError(
+                    message="message %(i)s",
+                    params={"i": 2},
+                ),
+            ]
+        )
+
+        e_copy = copy.copy(e)
+        self.assertEqual(e, e_copy)
+        self.assertEqual(e.as_data(), e_copy.as_data())
+
     def test_error_list_copy_attributes(self):
         class CustomRenderer(DjangoTemplates):
             pass
@@ -194,6 +212,16 @@ class FormsUtilsTestCase(SimpleTestCase):
 
         e_deepcopy = copy.deepcopy(e)
         self.assertEqual(e, e_deepcopy)
+
+    def test_error_dict_copy_attributes(self):
+        class CustomRenderer(DjangoTemplates):
+            pass
+
+        renderer = CustomRenderer()
+        e = ErrorDict(renderer=renderer)
+
+        e_copy = copy.copy(e)
+        self.assertEqual(e.renderer, e_copy.renderer)
 
     def test_error_dict_html_safe(self):
         e = ErrorDict()

--- a/tests/forms_tests/tests/test_utils.py
+++ b/tests/forms_tests/tests/test_utils.py
@@ -2,6 +2,7 @@ import copy
 import json
 
 from django.core.exceptions import ValidationError
+from django.forms.renderers import DjangoTemplates
 from django.forms.utils import (
     ErrorDict,
     ErrorList,
@@ -160,6 +161,17 @@ class FormsUtilsTestCase(SimpleTestCase):
             '<ul class="errorlist"><li>nameExample of link: '
             '<a href="http://www.example.com/">example</a></li></ul>',
         )
+
+    def test_error_list_copy_attributes(self):
+        class CustomRenderer(DjangoTemplates):
+            pass
+
+        renderer = CustomRenderer()
+        e = ErrorList(error_class="woopsies", renderer=renderer)
+
+        e_copy = e.copy()
+        self.assertEqual(e.error_class, e_copy.error_class)
+        self.assertEqual(e.renderer, e_copy.renderer)
 
     def test_error_dict_copy(self):
         e = ErrorDict()


### PR DESCRIPTION
#### Trac ticket number
ticket-35829

#### Branch description
While looking through the source code, I stumbled upon the [​https://github.com/django/django/tree/main/django/contrib/admin/static/admin/img](https://github.com/django/django/tree/main/django/contrib/admin/static/admin/img) directory.

From reading the provided information, these files were originally created by the Font Awesome project, although being converted to standalone SVG files by some third-party. As far as I can see, they have received some modifications for Django to set some other color for example.

There possibly are multiple license-related aspects which show up here (Disclaimer: IANAL):

Splitting the big SVG file as done by Font-Awesome-SVG-PNG might be considered derivative work with a new name per OFL-1.1 and at least is covered by the weak copyleft effect of the OFL-1.1. The MIT LICENSE file provided in the directory is clearly wrong here.
Changing the color of individual files or re-arranging them can more likely be considered derivative work, usually requiring using a different name under the terms of the OFL-1.1 and applying the OFL-1.1 to these files.
Given these observations, I would propose to update this directory accordingly:

Update Font Awesome to the latest version. Desktop releases for version 6.6.0 already provide individual SVG files which actually have a license comment inside as well.
Update the README and LICENSE file accordingly to indeed include the correct license text, id est the OFL-1.1 one. The README ideally documents which changes were done to which original version.

#### My changes
The changes I’ve made include:

Updating the icons in the django/contrib/admin/static/admin/img folder to the latest versions from Font Awesome Free 6.7.1.

Updating the README and LICENSE files in the same folder to reflect the changes and ensure compliance with Font Awesome's current licenses.

Additionally, I noticed that the django/contrib/admin/static/admin/img/gis folder contains some icons, but I’m unsure if those are still being used. I also couldn’t find equivalents for those icons in the Font Awesome library, so I’d appreciate guidance on how to proceed with them.

#### Checklist
- [ ] This PR targets the `main` branch. <!-- Backports will be evaluated and done by mergers, when necessary. -->
- [ ] The commit message is written in past tense, mentions the ticket number, and ends with a period.
- [ ] I have checked the "Has patch" ticket flag in the Trac system.
- [ ] I have added or updated relevant tests.
- [ ] I have added or updated relevant docs, including release notes if applicable.
- [ ] I have attached screenshots in both light and dark modes for any UI changes.
